### PR TITLE
Adjust formatting of success messages

### DIFF
--- a/nginx_ensite
+++ b/nginx_ensite
@@ -86,7 +86,7 @@ case $ACTION in
             echo "Testing nginx configuration..."
             $NGINX -t && STATUS=0
             if [ $STATUS ]; then
-                echo -n "site $1 has been enabled."
+                echo -n "Site $1 has been enabled. "
                 echo "Run /etc/init.d/nginx reload to apply the changes."
                 exit 0
             else
@@ -100,7 +100,7 @@ case $ACTION in
     DISABLE)
         if [ -h $SITE_ENABLED ]; then
             rm $SITE_ENABLED
-            echo "Site $1 has been disabled."
+            echo -n "Site $1 has been disabled. "
             echo "Run /etc/init.d/nginx reload to apply the changes."
             exit 0
         else


### PR DESCRIPTION
The success messages for enabling/disabling a site were inconsistent with each other, and the message after enabling a site was missing a space. This commit fixes both of these minor issues.

This is an entirely opinionated and OCD change; feel free to reject if you disagree with the formatting decision, or there's a reason for it that I missed.
