### PR TITLE
Fix disabling the default config on debian

### DIFF
--- a/nginx_ensite
+++ b/nginx_ensite
@@ -110,6 +110,12 @@ case $ACTION in
         fi
         ;;
     DISABLE)
+        #On debian the default is enabled as default, not 000-default
+        if [ "$1" = "default" ] ; then
+            if [ -h "$ENABLED_SITES_PATH/default" ] ; then
+                SITE_ENABLED="$ENABLED_SITES_PATH/default"
+           fi
+        fi
         if [ -h $SITE_ENABLED ]; then
             rm $SITE_ENABLED
             echo -n "Site $1 has been disabled. "


### PR DESCRIPTION
On a default debian install the default configuration is symlinked as /etc/nginx/sites-enabled/default so the script can't disable the domain. This patch fixes this particular case.