### PR TITLE
Added symlinks to find -type filter.

### DIFF
--- a/bash_completion.d/nginx_ensite
+++ b/bash_completion.d/nginx_ensite
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # nginx-ensite --- Bash completion function for nginx_ensite/nginx_dissite.
 
 # Copyright (C) 2010 António P. P. Almeida <appa@perusio.net>
@@ -15,6 +13,8 @@
 
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
+
+#!/bin/bash:wq
 
 # Except as contained in this notice, the name(s) of the above copyright
 # holders shall not be used in advertising or otherwise to promote the sale,
@@ -32,8 +32,9 @@
 ## Handling of both enabled and available sites.
 _nginx_sites() {
     # Get the available or enabled sites for nginx.
-    COMPREPLY=( $( compgen -W '$( command find /etc/nginx/$1 -type f -printf "%P " 2>/dev/null \
-               | sed 's/[.]conf$//' )' -- $cur  ) )
+    COMPREPLY=( $( compgen -W '$( command find /etc/nginx/$1 \
+      \( -type l -o -type f \) -printf "%P " 2>/dev/null \
+      | sed 's/[.]conf$//' )' -- $cur  ) )
 }
 
 _nginx_ensite()


### PR DESCRIPTION
It's a very common scenario to have /web/site/conf/site.conf
and to create a symlink in /etc/nginx/sites-available.

This script used find -type f to limit the search to files, so
I added and OR find -type l to accommodate symlinks too.

This is a super simple but super useful addition to your excellent work that shouldn't require much thought to just pull in (as it's not a complete refactoring like some other pull requests...